### PR TITLE
2.2.0 Add ability to override stroke-width by css var

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.0
+=======
+* allow user to override stroke-width by css var
+
 v2.1.11
 =======
 * add px-vis:reset

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "description": "Base icon styles for Predix UI",
   "private": false,
   "scripts": {

--- a/px-icon.html
+++ b/px-icon.html
@@ -25,6 +25,7 @@ limitations under the License.
         /* Create some vars we can manipulate asour icons change*/
         --px-icon-default-width: 22px;
         --px-icon-default-height: 22px;
+        --px-icon-stroke-width: 1;
 
         /* Update iron-icon vars so we can overwrite */
         --iron-icon-width: var(--px-icon-default-width);
@@ -45,6 +46,7 @@ limitations under the License.
 
         width: var(--iron-icon-width);
         height: var(--iron-icon-height);
+        stroke-width: var(--px-icon-stroke-width);
         @apply --iron-icon;
       }
       /* Also copied exactly from iron-icon */


### PR DESCRIPTION
In many cases, the very light line weight of the PX-Icons makes it hard to see on medium-color backgrounds (though they display as expected on white or dark backgrounds). This PR adds a css var (`--px-icon-stroke-width`) for overriding the stroke-width of any icon, of course defaulting to `1`.

This will allow the user to override the stroke width of any icon in their own application css.

Updated to semver `2.2.0` as this is introducing new functionality.